### PR TITLE
Fixed deploying workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -66,7 +66,7 @@ jobs:
             # convert markdown to html
             wget https://raw.githubusercontent.com/carnarez/markdown-tests/master/build/render.py
             find . -name "*.md" | while read f; do
-              echo -e "\n\n\n" | cat front-matter.txt - $f > tmp/$f; \
+              echo "\n" | cat front-matter.txt - $f > tmp/$f; \
               python render.py tmp/$f | cat front-matter.txt - > www/$(sed 's/.md$/.html/g' <<< $f)
             done
             # bundle css

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,6 +5,7 @@ FROM python:slim as render
 WORKDIR /usr/src
 
 COPY front-matter.txt .
+COPY render.py .
 COPY index.md .
 COPY template.html .
 
@@ -20,10 +21,10 @@ RUN apt-get update \
                                markdown \
                                pymdown-extensions \
                                pyyaml \
- && wget --quiet https://raw.githubusercontent.com/carnarez/markdown-tests/master/build/render.py \
+#&& wget --quiet https://raw.githubusercontent.com/carnarez/markdown-tests/master/build/render.py \
  && find . -name "*.md" | while read f; do \
       mkdir -p /var/www/`dirname $f`; \
-      echo "\n\n\n" | cat front-matter.txt - $f > /tmp/file.md; \
+      echo "\n" | cat front-matter.txt - $f > /tmp/file.md; \
       python render.py /tmp/file.md > /var/www/$(echo $f | sed 's/README/index/g;s/.md$/.html/g'); \
     done
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,7 +5,6 @@ FROM python:slim as render
 WORKDIR /usr/src
 
 COPY front-matter.txt .
-COPY render.py .
 COPY index.md .
 COPY template.html .
 
@@ -21,7 +20,7 @@ RUN apt-get update \
                                markdown \
                                pymdown-extensions \
                                pyyaml \
-#&& wget --quiet https://raw.githubusercontent.com/carnarez/markdown-tests/master/build/render.py \
+ && wget --quiet https://raw.githubusercontent.com/carnarez/markdown-tests/master/build/render.py \
  && find . -name "*.md" | while read f; do \
       mkdir -p /var/www/`dirname $f`; \
       echo "\n" | cat front-matter.txt - $f > /tmp/file.md; \


### PR DESCRIPTION
The behaviour of `cat -` is here... unexpected (at least to me), and the regular expression from the rendering script was too stiff.