### PR TITLE
Fixed rendering of methods with many arguments

### DIFF
--- a/astdocs/astdocs.py
+++ b/astdocs/astdocs.py
@@ -851,7 +851,7 @@ def render_class(
     if n in fs:
         fs.remove(n)
         details = functions.pop(n)
-        params = re.sub(r"self[\s,]*", "", details["params"], 1).strip()
+        params = re.sub(r"self[\s,]*", "", details["params"], 1)
         docstring = details["funcdocs"]
         beglineno = details["lineno"]
         endlineno = details["endlineno"]
@@ -869,9 +869,7 @@ def render_class(
             functions[f].update(
                 {
                     "hashtags": f"{ht}##",
-                    "params": re.sub(
-                        r"self[\s,]*", "", functions[f]["params"], 1
-                    ).strip(),
+                    "params": re.sub(r"self[\s,]*", "", functions[f]["params"], 1),
                 }
             )
             fsr.append(render_function(filepath, f, functions))

--- a/tests/README.md
+++ b/tests/README.md
@@ -414,6 +414,8 @@ All tests related to the `astdocs.render_*()` functions.
   `__init__` and methods.
 - [`test_complex_function()`](#test_rendertest_complex_function): Test for complex
   input/output arguments.
+- [`test_many_parameters()`](#test_rendertest_many_parameters): Test rendering for
+  function/method with many parameters.
 - [`test_private_hidden_objects()`](#test_rendertest_private_hidden_objects): Test for
   private objects.
 - [`test_private_visible_objects()`](#test_rendertest_private_visible_objects): Test for
@@ -510,6 +512,44 @@ def func(
 
 def _hidden():
     pass
+```
+
+### `test_render.test_many_parameters`
+
+```python
+test_many_parameters():
+```
+
+Test rendering for function/method with many parameters.
+
+```python
+def function(param1: float,
+             param2: int,
+             param3: str,
+             param4: str,
+             param5: list[str] = [],
+             param6: tuple[float, float, float] = (),
+             param7: dict[int, str] = [],
+             *args,
+             **kwargs):
+    """This does everything and more."""
+
+class Classy(Parent):
+    """A classy class."""
+
+    def method(
+        self,
+        param1: float,
+        param2: int,
+        param3: str,
+        param4: str,
+        param5: list[str] = [],
+        param6: tuple[float, float, float] = (),
+        param7: dict[int, str] = [],
+        *args,
+        **kwargs,
+    ):
+        pass
 ```
 
 ### `test_render.test_private_hidden_objects`

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -249,8 +249,149 @@ Do this and that.
     """.strip()
 
     n = ast.parse(s).body[1]
-    functions = astdocs.parse_function(n, MODULE, MODULE, {})
+    functions = astdocs.parse_function(n, MODULE, MODULE, {})  # type: ignore
     rendered = astdocs.render_function(f"{MODULE}.py", f"{MODULE}.func", functions)
+
+    assert rendered == r
+
+
+def test_many_parameters():
+    '''Test rendering for function/method with many parameters.
+
+    ```python
+    def function(param1: float,
+                 param2: int,
+                 param3: str,
+                 param4: str,
+                 param5: list[str] = [],
+                 param6: tuple[float, float, float] = (),
+                 param7: dict[int, str] = [],
+                 *args,
+                 **kwargs):
+        """This does everything and more."""
+
+    class Classy(Parent):
+        """A classy class."""
+
+        def method(
+            self,
+            param1: float,
+            param2: int,
+            param3: str,
+            param4: str,
+            param5: list[str] = [],
+            param6: tuple[float, float, float] = (),
+            param7: dict[int, str] = [],
+            *args,
+            **kwargs,
+        ):
+            pass
+    ```
+    '''
+    astdocs.objects[MODULE] = {"classes": {}, "functions": {}, "imports": {}}
+    astdocs.astdocs._update_templates(astdocs.config)
+
+    # source
+    s = '''
+def function(param1: float,
+             param2: int,
+             param3: str,
+             param4: str,
+             param5: list[str] = [],
+             param6: tuple[float, float, float] = (),
+             param7: dict[int, str] = [],
+             *args,
+             **kwargs):
+    """This does everything and more."""
+
+class Classy(Parent):
+    """A classy class."""
+
+    def method(
+        self,
+        param1: float,
+        param2: int,
+        param3: str,
+        param4: str,
+        param5: list[str] = [],
+        param6: tuple[float, float, float] = (),
+        param7: dict[int, str] = [],
+        *args,
+        **kwargs,
+    ):
+        pass
+    '''.strip()
+
+    # target
+    r = """
+# Module `test`
+
+**Functions**
+
+* [`function()`](#testfunction): This does everything and more.
+
+**Classes**
+
+* [`Classy`](#testclassy): A classy class.
+
+## Functions
+
+### `test.function`
+
+```python
+function(
+    param1: float,
+    param2: int,
+    param3: str,
+    param4: str,
+    param5: list[str] = [],
+    param6: tuple[float, float, float] = (),
+    param7: dict[int, str] = [],
+    *args,
+    **kwargs,
+):
+```
+
+This does everything and more.
+
+## Classes
+
+### `test.Classy`
+
+A classy class.
+
+**Methods**
+
+* [`method()`](#testclassymethod)
+
+#### Constructor
+
+```python
+Classy()
+```
+
+#### Methods
+
+##### `test.Classy.method`
+
+```python
+method(
+    param1: float,
+    param2: int,
+    param3: str,
+    param4: str,
+    param5: list[str] = [],
+    param6: tuple[float, float, float] = (),
+    param7: dict[int, str] = [],
+    *args,
+    **kwargs,
+):
+```
+    """.strip()
+
+    n = ast.parse(s)
+    classes, functions, imports = astdocs.parse(n, MODULE, MODULE)
+    rendered = astdocs.render(code=s, module=MODULE)
 
     assert rendered == r
 


### PR DESCRIPTION
Removed the `.strip()` that caused removing the line breaks (leading and trailing) when rendering.